### PR TITLE
fix: node download link

### DIFF
--- a/docs/guide/getting-started/preparing.md
+++ b/docs/guide/getting-started/preparing.md
@@ -3,4 +3,4 @@
 
 After installing and IDE you need to install node.
 
-You can download the LTS version of node right [here](https://nodejs.org/en/download/release/latest/)
+You can download the LTS version of node right [here](https://nodejs.org/en/download/)


### PR DESCRIPTION
- Fixes the download link for node in the [docs](https://sern-handler.js.org/docs/guide/getting-started/preparing)