### PR TITLE
chore: change srizan domain from ml to dev

### DIFF
--- a/blog/2022-12-13-mdx-blog-post.md
+++ b/blog/2022-12-13-mdx-blog-post.md
@@ -132,7 +132,7 @@ Post 2.0:
 
 CommandPlugin<T\> and EventPlugin<T\> typings have also been static'ified, transformed from types to interfaces
 ## Breaking Changes
-<img src="https://img.srizan.ml/Discord_z8Sn1UBfEe.png" />
+<img src="https://img.srizan.dev/Discord_z8Sn1UBfEe.png" />
 <br />
 All deprecation warnings from previous versions have taken effect, and are removed in 2.0.
 


### PR DESCRIPTION
i think this marks the ninth (woah wtf) PR made to this repo by me
this changes one image url in the 2.0 blogpost, thus it doesn't need much review to merge (i hope)

<img src="https://cdn.discordapp.com/emojis/1028369904824504320.webp?size=80&quality=lossless">