### PR TITLE
Plugin Card Aligning

### DIFF
--- a/src/components/PluginCard/index.module.css
+++ b/src/components/PluginCard/index.module.css
@@ -2,7 +2,6 @@
     display: flex;
     flex-direction: column;
     justify-content: space-between;
-    width: 25%;
     height: 100%;
     padding: 1rem;
     border-radius: 0.5rem;

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -26,10 +26,17 @@
 }
 
 .cntnr {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    width: 85%;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
     justify-content: center;
     max-width: 1500px;
     gap: 1rem;
     margin: 2rem auto;
+}
+
+@media only screen and (max-width: 800px) {
+  .cntnr {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
 }

--- a/src/pages/plugins.js
+++ b/src/pages/plugins.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import Layout from '@theme/Layout';
-import clsx from "clsx";
 import styles from "./index.module.css";
 import PluginCard from "../components/PluginCard";
 


### PR DESCRIPTION
Switches plugin cards to use a grid rather than flex (also improved responsiveness since grid will shrink to two columns for small screens.

# Before:
<img width="1077" alt="image" src="https://github.com/sern-handler/website/assets/47304910/3dc90304-1585-4238-84d3-e58456ebea57">

# After:
![after](https://github.com/sern-handler/website/assets/47304910/ef97b59a-b10a-44f7-a870-9a5df05c7cf1)
