### PR TITLE
edit: params is for MessageComponents

### DIFF
--- a/src/content/docs/v4/transition/from-v3.mdx
+++ b/src/content/docs/v4/transition/from-v3.mdx
@@ -15,7 +15,7 @@ export default commandModule({
     type: CommandType.Slash,
     description: "My ping command",
     execute: (ctx, sdt) => {
-        sdt.params // only exists if current command is not a component
+        sdt.params // only exists if current command is a component (dynamic custom ids)
         sdt.deps // Dependencies 
         sdt.type // module type
     }


### PR DESCRIPTION
Just to note what the params is.
*params* are for message components dynamic custom ids. When you have a command that returns multiple message components like buttons or menus or modals and your customId starts with `id/arg`, you can use one commandModule rather than multiples to control what each one does.