### PR TITLE
Add tip for multiple commands dirs

### DIFF
--- a/src/content/docs/v4/reference/config.mdx
+++ b/src/content/docs/v4/reference/config.mdx
@@ -32,7 +32,12 @@ import { FileTree } from '@astrojs/starlight/components';
 ```js title='src/config.js'
 export const commands = './dist/commands'
 ```
-
+:::tip `commands` also supports an array of folders! 
+```js title='src/config.js'
+export const commands = ['./dist/commands', './dist/components']
+```
+This allows you to input your buttons, select menus, and modals separate from commands!
+:::
 We will pass this file so sern can start properly.
 
 ```js title='src/index.js'
@@ -68,10 +73,12 @@ export const OWNERS = ['182326315813306368']
 
 
 :::caution
-If you use javascript + common.js, star imports do not work. Please export an object default and put your configuration there.
-```js
-exports.default = {
-    commands : "./dist/commands",
-}
+Javascript + common.js is no longer supported! The following method will not work! 
+We use import/export context!
+```diff
+-exports.default = {
+-    commands : "./dist/commands",
+-}
++export const commands = './dist/commands';
 ```
 :::

--- a/src/content/docs/v4/reference/config.mdx
+++ b/src/content/docs/v4/reference/config.mdx
@@ -32,7 +32,8 @@ import { FileTree } from '@astrojs/starlight/components';
 ```js title='src/config.js'
 export const commands = './dist/commands'
 ```
-:::tip `commands` also supports an array of folders! 
+:::tip 
+`commands` also supports an array of folders! 
 ```js title='src/config.js'
 export const commands = ['./dist/commands', './dist/components']
 ```


### PR DESCRIPTION
After a recent patch, we can now use an array of folders to tell sern where to look for commands. Using an array, we can keep our commands separate from our components (ie: Select Menus, Buttons, Modals).  Additionally, patched the cautionary statement at the bottom of the page to signify we don't support CJS anymore.